### PR TITLE
Fix activar virtualenv en InstalacionMacLinux.md

### DIFF
--- a/InstalacionMacLinux.md
+++ b/InstalacionMacLinux.md
@@ -54,6 +54,7 @@ significa que debes escribir dentro de la aplicación que mencionamos abajo. (De
 
     5. Activar el virtualenv
     ```
+    cd yourenv
     source bin/activate
     ```
     El resultado en 'Terminal' debe de ser algo parecido a:


### PR DESCRIPTION
En Linux se debe estar en la carpeta del nuevo virtualenv si se desea ejecutar el comando tal como se encuentra en el subpunto 5